### PR TITLE
Use block actions for yes/no decisions

### DIFF
--- a/src/action_payloads.ts
+++ b/src/action_payloads.ts
@@ -1,0 +1,29 @@
+// see https://api.slack.com/reference/interaction-payloads/block-actions
+// this is a subset of the data present there
+export type ActionPayload = {
+  type: "block_actions";
+  user: {
+    id: string;
+    username: string;
+  };
+  actions: {
+    block_id: string;
+    action_id: string;
+    value: string;
+    action_ts: string;
+    type:
+      | "button"
+      | "checkboxes"
+      | "radio"
+      | "datepicker"
+      | "overflow"
+      | "plain_text_input"
+      | "rich_text_input"
+      | "multi_*_select"
+      | "*_select";
+  }[];
+  channel: {
+    id: string;
+    name: string;
+  };
+};

--- a/src/avalon.ts
+++ b/src/avalon.ts
@@ -692,6 +692,41 @@ export class Avalon {
         this.api.chat.postMessage({
           channel: this.playerDms[player.id],
           text: `${message}\nShould the quest \`succeed\` or \`fail\`?`,
+          blocks: [
+            {
+              type: "section",
+              text: {
+                type: "mrkdwn",
+                text: message,
+              },
+            },
+            {
+              type: "actions",
+              block_id: "quest-success-vote",
+              elements: [
+                {
+                  type: "button",
+                  text: {
+                    type: "plain_text",
+                    text: ":white_check_mark: Succeed",
+                    emoji: true,
+                  },
+                  value: "succeed",
+                  action_id: "succeed",
+                },
+                {
+                  type: "button",
+                  text: {
+                    type: "plain_text",
+                    text: ":x: Fail",
+                    emoji: true,
+                  },
+                  value: "fail",
+                  action_id: "fail",
+                },
+              ],
+            },
+          ],
         });
         return this.dmMessages(player)
           .where((e) => e.user === player.id && e.text)

--- a/src/avalon.ts
+++ b/src/avalon.ts
@@ -1,4 +1,8 @@
 "use strict";
+
+import { webApi } from "@slack/bolt";
+import { MessageAttachment } from "@slack/types";
+
 const rx = require("rx");
 const _ = require("lodash");
 const M = require("./message-helpers");
@@ -7,7 +11,7 @@ require("string_score");
 rx.config.longStackSupport = true;
 
 class GameUILayer {
-  api: any;
+  api: webApi.WebClient;
   message_stream: any;
 
   constructor(api, message_stream) {
@@ -102,7 +106,7 @@ export class Avalon {
   players: any;
   playerDms: any;
   gameUx: GameUILayer;
-  api: any;
+  api: webApi.WebClient;
   messages: any;
   date: any;
   scheduler: any;
@@ -389,14 +393,13 @@ export class Avalon {
   }
 
   broadcast(message, color?, special?) {
-    let attachment = {
+    let attachment: MessageAttachment = {
       fallback: message,
       text: message,
-      mrkdwn: true,
       mrkdwn_in: ["pretext", "text"],
       color: undefined,
       pretext: undefined,
-      thumb_url: undefined
+      thumb_url: undefined,
     };
     if (color) attachment.color = color;
     if (special == "start") {
@@ -440,7 +443,7 @@ export class Avalon {
         channel: this.playerDms[p.id],
         attachments: [attachment],
       });
-    })
+    });
   }
 
   dmMessages(player) {

--- a/src/avalon.ts
+++ b/src/avalon.ts
@@ -561,6 +561,41 @@ export class Avalon {
             this.api.chat.postMessage({
               channel: this.playerDms[p.id],
               text: `${message}\nVote with \`approve\` or \`reject\``,
+              blocks: [
+                {
+                  type: "section",
+                  text: {
+                    type: "mrkdwn",
+                    text: message,
+                  },
+                },
+                {
+                  type: "actions",
+                  block_id: "quest-team-vote",
+                  elements: [
+                    {
+                      type: "button",
+                      text: {
+                        type: "plain_text",
+                        text: ":white_check_mark: Approve",
+                        emoji: true,
+                      },
+                      value: "approve",
+                      action_id: "approve",
+                    },
+                    {
+                      type: "button",
+                      text: {
+                        type: "plain_text",
+                        text: ":x: Reject",
+                        emoji: true,
+                      },
+                      value: "reject",
+                      action_id: "reject",
+                    },
+                  ],
+                },
+              ],
             });
             return this.dmMessages(p)
               .where((e) => e.user === p.id && e.text)

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -3,6 +3,7 @@
 import { App } from "@slack/bolt";
 import { GenericMessageEvent } from "@slack/types";
 import * as rx from "rx";
+import { ActionPayload } from "./action_payloads";
 
 const _ = require("lodash");
 const SlackApiRx = require("./slack-api-rx");


### PR DESCRIPTION
This adds buttons to approve/reject teams, and succeed/fail quests.

This is a little cheesy - clicking on the buttons injects a synthetic message event into the messages observable that then gets processed exactly as if you had typed 'approve'. I intend to later shortcut this processing in [choosePlayersForQuest](https://github.com/hcarver/slack-avalon-bot/blob/f4cafb2c2ea3c3497f65916415c574ea13853b70/src/avalon.ts#L571) so that we directly inject the vote. (this would require more changes to the tests, although those have never run for me - something to do with no ts-node equivalent for that stuff?)

![Screenshot 2024-11-12 at 07 44 51](https://github.com/user-attachments/assets/a7a1c86a-8fa6-4f1b-8e74-3d38948916b3)
![Screenshot 2024-11-12 at 07 44 23](https://github.com/user-attachments/assets/0697bdba-c60a-42a1-aaa1-8869be0447fa)
