### PR TITLE
Fix malformed role data with > 1 games

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -37,7 +37,7 @@ export class Bot {
     // });
     this.api = this.bolt.client;
 
-    this.gameConfig = Avalon.DEFAULT_CONFIG;
+    this.gameConfig = structuredClone(Avalon.DEFAULT_CONFIG);
   }
 
   // Public: Brings this bot online and starts handling messages sent to it.


### PR DESCRIPTION
the role choice code mutates this.gameConfig.specialRoles (appending any selecting roles). However this still the array from Avalon.DEFAULT_CONFIG, so  the second & following games would not start from a clean state: the chosen roles would be concatenated with the previous game's & you could have multiple morgana/oberon/... etc players